### PR TITLE
tokenbroker-proxy helm chart update with new image

### DIFF
--- a/charts/snowsoftware-tokenbroker-proxy/Chart.yaml
+++ b/charts/snowsoftware-tokenbroker-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: snowsoftware-tokenbroker-proxy
 description: Converts between Mutual TLS (MTLS) and OAuth2 based authentication
-version: 1.0.1
+version: 1.0.2
 type: application

--- a/charts/snowsoftware-tokenbroker-proxy/README.md
+++ b/charts/snowsoftware-tokenbroker-proxy/README.md
@@ -13,6 +13,7 @@ These are all of the parameters the service requires:
 * Platform URL - URL to Snow Identity Provider
 * BrokerPort - Port on which the tokenbroker proxy service rus
 * BrokerHost - Host name for tokenbroker proxy service
+* Client Discriminator - field in the client certificate used for determining the client (usually email address). Supported values are "emailAddress", "CN", "OU"
 
 
 # Required Software
@@ -69,6 +70,7 @@ tokenbrokerProxy:
   platformurl: "<snow atlas identity provider URL>"
   brokerport: "8443" # default
   brokerhost: "localhost" # default
+  clientdiscriminator: emailAddress # supported values: "emailAddress", "OU", "CN"
 ```
 
 3. Run helm installation and provide the values.yaml file you just created (example using downloaded file)

--- a/charts/snowsoftware-tokenbroker-proxy/templates/deployment.yaml
+++ b/charts/snowsoftware-tokenbroker-proxy/templates/deployment.yaml
@@ -47,7 +47,8 @@ spec:
             "--signingcert=/certs/signingcert",
             "--platformurl={{ .Values.tokenbrokerProxy.platformurl }}",
             "--brokerport={{ .Values.tokenbrokerProxy.brokerport }}",
-            "--brokerhost={{ .Values.tokenbrokerProxy.brokerhost }}"
+            "--brokerhost={{ .Values.tokenbrokerProxy.brokerhost }}",
+            "--clientdiscriminator={{ .Values.tokenbrokerProxy.clientdiscriminator }}"
           ]
           volumeMounts:
             - name: certs

--- a/charts/snowsoftware-tokenbroker-proxy/values.yaml
+++ b/charts/snowsoftware-tokenbroker-proxy/values.yaml
@@ -1,9 +1,10 @@
 tokenbrokerProxy:
   name:  # If provided, this overrides the name of the deployment.
   repository: ghcr.io/snowsoftwareglobal/iam-tokenbroker-proxy
-  tag:        0.1.8
+  tag:        0.1.9
   imagePullPolicy: IfNotPresent
   replicas: 1 
+  clientdiscriminator: emailAddress # supported values: "emailAddress", "OU", "CN"
   
   labels: {}
   templateLabels: {}


### PR DESCRIPTION
Added support for clientDiscriminator field - it's used for getting the discriminator (eg. email address) from client's certificate. Before it was only the emailAddress field. Now it supports also OU and CN fields.