### PR TITLE
Update tokenbroker proxy to 0.1.11

### DIFF
--- a/charts/snowsoftware-tokenbroker-proxy/Chart.yaml
+++ b/charts/snowsoftware-tokenbroker-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: snowsoftware-tokenbroker-proxy
 description: Converts between Mutual TLS (MTLS) and OAuth2 based authentication
-version: 1.0.2
+version: 1.0.3
 type: application

--- a/charts/snowsoftware-tokenbroker-proxy/values.yaml
+++ b/charts/snowsoftware-tokenbroker-proxy/values.yaml
@@ -1,7 +1,7 @@
 tokenbrokerProxy:
   name:  # If provided, this overrides the name of the deployment.
   repository: ghcr.io/snowsoftwareglobal/iam-tokenbroker-proxy
-  tag:        0.1.9
+  tag:        0.1.11
   imagePullPolicy: IfNotPresent
   replicas: 1 
   clientdiscriminator: emailAddress # supported values: "emailAddress", "OU", "CN"


### PR DESCRIPTION
Updates go to address CVE-2023-44487
Bundles tokenbroker proxy scratch image with alpine CA certificate chain