### PR TITLE
add a link to the tokenbroker readme from the main readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Official Helm charts for Snow Software
 
-See [Snow Software Kubernetes Connector](charts/snowsoftware-connector-k8s/README.md) for detailed instructions.
+See [Snow Software Kubernetes Connector](charts/snowsoftware-connector-k8s/README.md) for detailed instructions on configuring the container connector.
 
-See [Snow Software Tokenbroker Proxy](charts/snowsoftware-tokenbroker-proxy/README.md) for detailed instructions.
+See [Snow Software Tokenbroker Proxy](charts/snowsoftware-tokenbroker-proxy/README.md) for detailed instructions on configuring the tokenbroker proxy.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # Official Helm charts for Snow Software
 
 See [Snow Software Kubernetes Connector](charts/snowsoftware-connector-k8s/README.md) for detailed instructions.
+
+See [Snow Software Tokenbroker Proxy](charts/snowsoftware-tokenbroker-proxy/README.md) for detailed instructions.


### PR DESCRIPTION
Updates the main readme file to link to tokenbroker proxy. Rewords references since there are now more than one.